### PR TITLE
Fix invalid embed style code

### DIFF
--- a/src/stylesControl.js
+++ b/src/stylesControl.js
@@ -28,7 +28,7 @@ export default class stylesControl {
           this.currentStyle = event.target.value
           const style = this.styleUrl.replace('%s', event.target.value)
           this.map.setStyle(style)
-        })
+        }, true)
       })
 
     return this.container


### PR DESCRIPTION
Closes #21 

getStyle の this.currentStyle が一つ前の値を取得していたので、

```
        this.select.addEventListener('change', event => {
          this.currentStyle = event.target.value
          const style = this.styleUrl.replace('%s', event.target.value)
          this.map.setStyle(style)
        }, ture)
```

が実行される優先順位を上げるために、 addEventListnener の第三引数 useCapture を true にしました。

https://developer.mozilla.org/ja/docs/Web/API/EventTarget/addEventListener#:~:text=%E5%88%A9%E7%94%A8%E3%81%A7%E3%81%8D%E3%81%BE%E3%81%99%E3%80%82-,useCapture,-%E7%9C%81%E7%95%A5%E5%8F%AF