### PR TITLE
Community Geocoder のオプションを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,23 @@ https://geolonia.github.io/get-geolonia/app.js
 <script type="text/javascript" src="https://cdn.geolonia.com/v1/embed?geolonia-api-key=YOUR-API-KEY"></script>
 <script type="text/javascript" src="https://geolonia.github.io/get-geolonia/app.js"></script>
 ```
+
+## Options
+
+```html
+<button
+  class="launch-get-geolonia"
+
+  # see docs.geolonia.com/embed
+  data-style="geolonia/midnight"
+  data-lng="123.45"
+  data-lat="45.67"
+  data-zoom="10"
+  data-geojson="https://example.com/path/to/geojson"
+  data-simple-vector="https://example.com/path/to/simplevector"
+  data-marker="off"
+
+  data-demo="on" # 'on' | 'off'
+  data-geocoder="community-geocoder" # 'community-geocoder' | 'off'
+>Get Geolonia</button>
+```

--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@ https://geolonia.github.io/get-geolonia/app.js
   data-geocoder="community-geocoder" # 'community-geocoder' | 'off'
 >Get Geolonia</button>
 ```
+
+NOTE: `data-geocoder="community-geocoder"` requires community-geocoder API with `<script src="https://cdn.geolonia.com/community-geocoder.js"></script>` at first.

--- a/docs/index.html
+++ b/docs/index.html
@@ -45,7 +45,18 @@
     </button>
   </p>
 
+  <!-- include community geocoder -->
+  <p>
+    <button
+      class="launch-get-geolonia"
+      data-geocoder="community-geocoder"
+    >
+      Get Geolonia
+    </button>
+  </p>
+
   <script type="text/javascript" src="https://cdn.geolonia.com/v1/embed?geolonia-api-key=YOUR-API-KEY"></script>
+  <script type="text/javascript" src="https://cdn.geolonia.com/community-geocoder.js"></script>
   <script src="./app.js"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@babel/plugin-transform-classes": "^7.10.1",
         "@babel/preset-env": "^7.10.2",
         "@babel/register": "^7.10.1",
+        "@mapbox/geojson-extent": "^1.0.1",
         "babel-loader": "^8.0.4",
         "core-js": "^3.6.5",
         "css-loader": "^2.1.0",
@@ -1608,6 +1609,46 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@mapbox/extent": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/extent/-/extent-0.4.0.tgz",
+      "integrity": "sha1-PlkfMuHww5gchkI597CsBuYQ+Kk=",
+      "dev": true
+    },
+    "node_modules/@mapbox/geojson-coords": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-coords/-/geojson-coords-0.0.2.tgz",
+      "integrity": "sha512-YuVzpseee/P1T5BWyeVVPppyfmuXYHFwZHmybkqaMfu4BWlOf2cmMGKj2Rr92MwfSTOCSUA0PAsVGRG8akY0rg==",
+      "dev": true,
+      "dependencies": {
+        "@mapbox/geojson-normalize": "0.0.1",
+        "geojson-flatten": "^1.0.4"
+      }
+    },
+    "node_modules/@mapbox/geojson-extent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-extent/-/geojson-extent-1.0.1.tgz",
+      "integrity": "sha512-hh8LEO3djT4fqfr8sSC6wKt+p0TMiu+KOLMBUiFOyj+zGq7+IXwQGl0ppCVDkyzCewyd9LoGe9zAvDxXrLfhLw==",
+      "dev": true,
+      "dependencies": {
+        "@mapbox/extent": "0.4.0",
+        "@mapbox/geojson-coords": "0.0.2",
+        "rw": "~0.1.4",
+        "traverse": "~0.6.6"
+      },
+      "bin": {
+        "geojson-extent": "bin/geojson-extent"
+      }
+    },
+    "node_modules/@mapbox/geojson-normalize": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-normalize/-/geojson-normalize-0.0.1.tgz",
+      "integrity": "sha1-HaHms6et060pkJsw9Dj2BYG3zYA=",
+      "dev": true,
+      "bin": {
+        "geojson-normalize": "geojson-normalize"
       }
     },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
@@ -5219,6 +5260,28 @@
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/geojson-flatten": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/geojson-flatten/-/geojson-flatten-1.0.4.tgz",
+      "integrity": "sha512-PpscUXxO6dvvhZxtwuqiI5v+1C/IQYPJRMWoQeaF2oohJgfGYSHKVAe8L+yUqF34PH/hmq9JlwmO+juPw+95/Q==",
+      "dev": true,
+      "dependencies": {
+        "get-stdin": "^7.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "geojson-flatten": "geojson-flatten"
+      }
+    },
+    "node_modules/geojson-flatten/node_modules/get-stdin": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/get-caller-file": {
@@ -9633,6 +9696,12 @@
         "aproba": "^1.1.1"
       }
     },
+    "node_modules/rw": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-0.1.4.tgz",
+      "integrity": "sha1-SQPL2AJIrg7eaFv1j9I2p6mymj4=",
+      "dev": true
+    },
     "node_modules/rxjs": {
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
@@ -11197,6 +11266,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
     },
     "node_modules/trim-newlines": {
       "version": "1.0.0",
@@ -13890,6 +13965,40 @@
         "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@mapbox/extent": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/extent/-/extent-0.4.0.tgz",
+      "integrity": "sha1-PlkfMuHww5gchkI597CsBuYQ+Kk=",
+      "dev": true
+    },
+    "@mapbox/geojson-coords": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-coords/-/geojson-coords-0.0.2.tgz",
+      "integrity": "sha512-YuVzpseee/P1T5BWyeVVPppyfmuXYHFwZHmybkqaMfu4BWlOf2cmMGKj2Rr92MwfSTOCSUA0PAsVGRG8akY0rg==",
+      "dev": true,
+      "requires": {
+        "@mapbox/geojson-normalize": "0.0.1",
+        "geojson-flatten": "^1.0.4"
+      }
+    },
+    "@mapbox/geojson-extent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-extent/-/geojson-extent-1.0.1.tgz",
+      "integrity": "sha512-hh8LEO3djT4fqfr8sSC6wKt+p0TMiu+KOLMBUiFOyj+zGq7+IXwQGl0ppCVDkyzCewyd9LoGe9zAvDxXrLfhLw==",
+      "dev": true,
+      "requires": {
+        "@mapbox/extent": "0.4.0",
+        "@mapbox/geojson-coords": "0.0.2",
+        "rw": "~0.1.4",
+        "traverse": "~0.6.6"
+      }
+    },
+    "@mapbox/geojson-normalize": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-normalize/-/geojson-normalize-0.0.1.tgz",
+      "integrity": "sha1-HaHms6et060pkJsw9Dj2BYG3zYA=",
+      "dev": true
     },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.2",
@@ -16894,6 +17003,24 @@
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
+    },
+    "geojson-flatten": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/geojson-flatten/-/geojson-flatten-1.0.4.tgz",
+      "integrity": "sha512-PpscUXxO6dvvhZxtwuqiI5v+1C/IQYPJRMWoQeaF2oohJgfGYSHKVAe8L+yUqF34PH/hmq9JlwmO+juPw+95/Q==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^7.0.0",
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+          "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+          "dev": true
+        }
+      }
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -20382,6 +20509,12 @@
         "aproba": "^1.1.1"
       }
     },
+    "rw": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-0.1.4.tgz",
+      "integrity": "sha1-SQPL2AJIrg7eaFv1j9I2p6mymj4=",
+      "dev": true
+    },
     "rxjs": {
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
@@ -21695,6 +21828,12 @@
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
       }
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
     },
     "trim-newlines": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@babel/plugin-transform-classes": "^7.10.1",
     "@babel/preset-env": "^7.10.2",
     "@babel/register": "^7.10.1",
+    "@mapbox/geojson-extent": "^1.0.1",
     "babel-loader": "^8.0.4",
     "core-js": "^3.6.5",
     "css-loader": "^2.1.0",

--- a/src/CommunityGeocoderControl.js
+++ b/src/CommunityGeocoderControl.js
@@ -1,0 +1,131 @@
+import geojsonExtent from '@mapbox/geojson-extent'
+
+export class CommunityGeocoderControl {
+  constructor(options) {
+    this.lat = options.lat
+    this.lng = options.lng
+  }
+
+  onAdd(map) {
+    const onsubmit = this._onsubmit.bind(this)
+
+    const container = document.createElement('form')
+    container.style.margin = '8px'
+    container.style.pointerEvents = 'auto'
+    container.onsubmit = onsubmit
+
+    const input = document.createElement('input')
+    input.className = 'mapbox-gl-control-community-geocoder-text-input'
+    input.type = 'text'
+    input.placeholder = '住所を入力してください。'
+    container.appendChild(input)
+
+    const button = document.createElement('button')
+    button.className = 'mapbox-gl-control-community-geocoder-button'
+    button.type = 'button'
+    button.innerText = '検索'
+    button.disabled = 'disabled'
+    button.addEventListener('click', onsubmit)
+    container.appendChild(button)
+
+    const message = document.createElement('p')
+    message.className = 'mapbox-gl-control-community-geocoder-message'
+    message.style.display = 'none'
+    container.appendChild(message)
+
+    input.addEventListener('keyup', (e) => {
+      if(e.target.value) {
+        button.removeAttribute('disabled')
+      } else {
+        button.setAttribute('disabled', 'disabled')
+      }
+    })
+    input.addEventListener('keydown', (e) => {
+      this.showMessage(false)
+    })
+
+    this.map = map
+    this.container = container
+    this.input = input
+    this.button = button
+    this.message = message
+    return container
+  }
+
+  showMessage(value) {
+    if(value === false) {
+      this.message.style.display = 'none'
+    } else {
+      this.message.innerText = value
+      this.message.style.display = 'block'
+    }
+  }
+
+  _onsubmit() {
+    const address = this.input.value
+    if(address) {
+      window.getLatLng(
+        address,
+        latlng => {
+          // eslint-disable-next-line no-console
+          console.log(latlng)
+          if (latlng.level === 1) {
+            const endpoint = 'https://geolonia.github.io/japanese-prefectural-capitals/index.json'
+            fetch(endpoint).then(res => {
+              return res.json()
+            }).then(data => {
+              this.map.flyTo({ center: data[latlng.pref], zoom: 9, essential: true })
+              this.showMessage(`住所の判定ができなかったので「${latlng.pref}」に移動します。`)
+            })
+          } else if (latlng.level === 2) {
+            const endpoint = 'https://geolonia.github.io/jisx0402/api/v1/all.json'
+            fetch(endpoint).then(res => {
+              return res.json()
+            }).then(data => {
+              const keys = Object.keys(data)
+              const values = Object.values(data)
+              const index = values.findIndex(value => value.prefecture === latlng.pref && value.city === latlng.city)
+              const code = keys[index].substr(0, 5)
+
+              const endpoint = `https://geolonia.github.io/japanese-admins/${code.substr(0, 2)}/${code}.json`
+              fetch(endpoint).then(res => {
+                return res.json()
+              }).then(data => {
+                this.map.fitBounds(geojsonExtent(data))
+                this.map.addLayer({
+                  id: 'japanese-administration',
+                  type: 'fill',
+                  source: {
+                    type: 'geojson',
+                    data: data,
+                  },
+                  layout: {},
+                  paint: {
+                    'fill-color': '#ff0000',
+                    'fill-opacity': 0.08,
+                  },
+                })
+                this.showMessage(`住所の判定ができなかったので「${data.features[0].properties.name}」に移動します。`)
+              })
+            })
+          } else {
+            this.map.flyTo({ center: latlng, zoom: 16, essential: true })
+          }
+        },
+        (err) => {
+          console.error(err)
+          this.showMessage(err.message || '不明なエラーです。')
+        }
+      )
+    }
+    return false
+  }
+
+  onRemove() {
+    this.container.parentNode.removeChild(this.container)
+    /* eslint no-undefined: 0 */
+    this.map = undefined
+  }
+}
+
+export default CommunityGeocoderControl

--- a/src/CommunityGeocoderControl.js
+++ b/src/CommunityGeocoderControl.js
@@ -70,6 +70,7 @@ export class CommunityGeocoderControl {
           // eslint-disable-next-line no-console
           console.log(latlng)
           if (latlng.level === 1) {
+            console.log({latlng})
             const endpoint = 'https://geolonia.github.io/japanese-prefectural-capitals/index.json'
             fetch(endpoint).then(res => {
               return res.json()
@@ -92,19 +93,6 @@ export class CommunityGeocoderControl {
                 return res.json()
               }).then(data => {
                 this.map.fitBounds(geojsonExtent(data))
-                this.map.addLayer({
-                  id: 'japanese-administration',
-                  type: 'fill',
-                  source: {
-                    type: 'geojson',
-                    data: data,
-                  },
-                  layout: {},
-                  paint: {
-                    'fill-color': '#ff0000',
-                    'fill-opacity': 0.08,
-                  },
-                })
                 this.showMessage(`住所の判定ができなかったので「${data.features[0].properties.name}」に移動します。`)
               })
             })

--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@ import './style.scss'
 import svg from './marker.svg'
 import closeSvg from './close.svg'
 import stylesControl from './stylesControl'
+import { CommunityGeocoderControl } from './communityGeocoderControl'
 
 const defaultLat = 35.6762
 const defaultLng = 139.6503
@@ -17,7 +18,7 @@ const camelToKebab = (str) =>  {
 }
 
 const buildAttributeText = (options) => {
-  const attributeDenyList = ['demo']
+  const attributeDenyList = ['demo', 'geocoder']
 
   // data-marker depends on data-lat and data-lng. https://docs.geolonia.com
   // The simpler the snipet, the better.
@@ -155,6 +156,17 @@ const app = btn => {
         style.getSelect().addEventListener('change', writeCode)
         map.on('moveend', writeCode)
       })
+    }
+
+    switch (options.geocoder) {
+      case 'community-geocoder':
+        map.on('load', () => {
+          const communityGeocoderControl = new CommunityGeocoderControl(options)
+          map.addControl(communityGeocoderControl, 'bottom-left')
+        })
+        break;
+      default:
+        break;
     }
   })
 }

--- a/src/style.scss
+++ b/src/style.scss
@@ -147,4 +147,25 @@
     border-radius: 0;
     outline: none;
   }
+
+  .mapbox-gl-control-community-geocoder-text-input
+  {
+    padding-left: 6px;
+    padding-right: 6px;
+    margin-right: .3em;
+    height: 24px;
+    width: 200px;
+    box-sizing: border-box;
+    border: 1px solid #cccccc;
+    border-radius: 0;
+    outline: none;
+  }
+
+  .mapbox-gl-control-community-geocoder-message
+  {
+    margin-top: .2em;
+    margin-bottom: .1em;
+    color: red;
+    background-color: rgba(255, 255, 255, .6);
+  }
 }


### PR DESCRIPTION
`data-geocoder="community-geocoder"` で Community Geocoder 用の UI を表示するように修正しました。
<img width="399" alt="スクリーンショット 2021-09-16 9 29 56" src="https://user-images.githubusercontent.com/6292312/133530520-5977ca60-9a22-4bbb-9725-674b39518f5a.png">
<img width="422" alt="スクリーンショット 2021-09-16 9 30 10" src="https://user-images.githubusercontent.com/6292312/133530521-e4258c58-c9e9-41d8-8c8b-cd4643a40611.png">
